### PR TITLE
[traefik][local-homelab] Use wildcard certificate via dns challenge

### DIFF
--- a/longhorn/overlays/local-homelab/ingress.yaml
+++ b/longhorn/overlays/local-homelab/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: longhorn
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: true
 spec:
   rules:
     - host: longhorn.local.aeoly.us

--- a/personal-website/base/ingress.yaml
+++ b/personal-website/base/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: personal-website
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: true
 spec:
   rules:
     - host: aeoly.us

--- a/prometheus/overlays/local-homelab/ingress.yaml
+++ b/prometheus/overlays/local-homelab/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: prometheus-ingress
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: true
 spec:
   rules:
     - host: prometheus.local.aeoly.us

--- a/traefik/components/wildcard-certificates/deployment.yaml
+++ b/traefik/components/wildcard-certificates/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traefik
+  namespace: traefik-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: traefik
+          env:
+            - name: TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS
+              value: "true"
+            - name: TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_DOMAINS_0_MAIN
+              value: "local.aeoly.us"
+            - name: TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_DOMAINS_0_SANS
+              value: "*.local.aeoly.us"
+            - name: TRAEFIK_ENTRYPOINTS_WEBSECURE_HTTP_TLS_CERTRESOLVER
+              value: "default"
+            - name: TRAEFIK_CERTIFICATESRESOLVERS_DEFAULT_ACME_STORAGE
+              value: "/data/acme.json"
+            - name: TRAEFIK_CERTIFICATESRESOLVERS_DEFAULT_ACME_DNSCHALLENGE_PROVIDER
+              value: "cloudflare"
+            - name: CF_API_EMAIL
+              value: "richardhuang.huang@gmail.com"
+            - name: CF_API_KEY
+              value: ""

--- a/traefik/components/wildcard-certificates/kustomization.yaml
+++ b/traefik/components/wildcard-certificates/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - deployment.yaml

--- a/traefik/overlays/local-homelab/ingress.yaml
+++ b/traefik/overlays/local-homelab/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: traefik-system
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: true
 spec:
   rules:
     - host: traefik.local.aeoly.us

--- a/traefik/overlays/local-homelab/kustomization.yaml
+++ b/traefik/overlays/local-homelab/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 components:
   - ../../components/longhorn
   - ../../components/dashboard
+  - ../../components/wildcard-certificates

--- a/whoami/base/ingress.yaml
+++ b/whoami/base/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: whoami
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: true
 spec:
   rules:
     - host: whoami.aeoly.us

--- a/whoami/overlays/local-homelab/ingress.yaml
+++ b/whoami/overlays/local-homelab/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: whoami
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: true
 spec:
   rules:
     - host: whoami.local.aeoly.us


### PR DESCRIPTION
- [traefik][local-homelab] Remove ingress TLS annotation since TLS is default
- [traefik][local-homelab] Add wildcard certificate component
- [traefik][local-homelab] Use traefik wildcard certificate component in local-homelab overlay
